### PR TITLE
add get_mac func for MAC sierra

### DIFF
--- a/src/ifaces.c
+++ b/src/ifaces.c
@@ -36,6 +36,11 @@
 #include <net/if.h>
 #include <net/if_arp.h>
 
+#ifdef __APPLE__
+#include <ifaddrs.h>
+#include <net/if_dl.h>
+#endif
+
 #include "screen.h"
 #include "ifaces.h"
 #include "data_al.h"
@@ -64,8 +69,6 @@
 #define ARPOP_REQUEST 1
 #define ARPOP_REPLY 2
 #endif
-
-
 
 
 /* Shitty globals */
@@ -173,6 +176,40 @@ void process_arp_header(struct data_registry *new_reg, const u_char* packet)
             packet[38], packet[39], packet[40], packet[41]);
 }
 
+#ifdef __APPLE__
+int get_mac(char *dev, unsigned char *mac)
+{
+    struct ifaddrs *if_addrs = NULL;
+    struct ifaddrs *if_addr = NULL;
+    void *tmp = NULL;
+    char buf[INET6_ADDRSTRLEN];
+    int found = 0;
+
+    if (getifaddrs(&if_addrs) != 0)
+    {
+        return 0;
+    }
+
+    for (if_addr = if_addrs; if_addr != NULL; if_addr = if_addr->ifa_next)
+    {
+        if (if_addr->ifa_addr != NULL && if_addr->ifa_addr->sa_family == AF_LINK && 
+            strcmp(dev, if_addr->ifa_name) == 0)
+        {
+            struct sockaddr_dl *sdl = (struct sockaddr_dl *)if_addr->ifa_addr;
+
+            if (6 == sdl->sdl_alen)
+            {
+                memcpy(mac, LLADDR(sdl), sdl->sdl_alen);
+                found = 1;
+                break;
+            }            
+        }
+    }
+
+    return 1;
+}
+#endif /* __APPLE__ */
+
 /* Init device for libpcap and get mac addr */
 void inject_init(char *disp)
 {
@@ -186,6 +223,9 @@ void inject_init(char *disp)
       exit(1);
    }
 
+#ifdef __APPLE__
+   get_mac(disp, smac);
+#else
    /* Get our mac addr */
    if (ourmac == NULL) {
       struct ifreq ifr;
@@ -220,6 +260,7 @@ void inject_init(char *disp)
       unsigned char* mac=(unsigned char*)ifr.ifr_hwaddr.sa_data;
       memcpy(smac, mac, ETH_ALEN);
    }
+#endif
 
 }
 


### PR DESCRIPTION
Somehow, the "SIOCGIFHWADDR" is not supported in macOS 10.12, I refer to other's suggestion to 
add a new function "get_mac" to make it work on MAC sierra.  

This patch is conditional compiler with __APPLE__, and only test with macOS 10.12 and Debian Linux.

Welcome any comment.