### PR TITLE
Fixes compilation issue on macOS due to platform specific headers.

### DIFF
--- a/src/ifaces.c
+++ b/src/ifaces.c
@@ -65,7 +65,10 @@
 #define ARPOP_REPLY 2
 #endif
 
-
+#ifdef __APPLE__
+#define SIOCGIFHWADDR SIOCGIFCONF
+#define ifr_hwaddr ifr_addr
+#endif
 
 
 /* Shitty globals */


### PR DESCRIPTION
Using preprocessor to fix a compilation issue on macOS due to platform specific headers.