### PR TITLE
Fixed typos, changed packet lossing to packet loss

### DIFF
--- a/README
+++ b/README
@@ -4,17 +4,17 @@ also works on hub/switched networks. Its based on arp packets, it will send arp
 requests and sniff for replys.
 
 Its my first public C tool, so dont be too hard with me, if some parts on the
-code looks like offuscated or are unreadable, and feel free to mail me with 
+code looks like obfuscated or are unreadable, and feel free to mail me with 
 suggestions or patches at <jpenalbae@gmail.com>
 
 Also mail me for any bug or compilation error, it must compile with gcc 2.95 or
 newer.
 
-An excesive cpu comsuption happens on OpenBSD, due to threads design and the
+An excessive cpu consumption happens on OpenBSD, due to threads design and the
 use of pcap_open_live() with pcap_loop(), any sugestions for fix are welcome.
 
 
-Requeriments
+Requirements
 ============
 
  - libpcap
@@ -66,9 +66,9 @@ Usage: ./netdiscover [-i device] [-r range | -p] [-s time] [-n node] [-c count] 
     if the default host is already used (from 2 to 253) (default 66)
 
   -S
-    Enable sleep time supression betwen each request. I will sleep each 255
+    Enable sleep time suppression between each request. I will sleep each 255
     scanned hosts instead of do it by each one, this mode was used on 0.3 beta4
-    and older releases. Avoid this option on networks with packet lossing,
+    and older releases. Avoid this option on networks with packet loss,
     or in wireless networks with low signal level. (also called hardcore mode)
 
   -f


### PR DESCRIPTION
Hey Alexey and Jaime,

first of all, I really like your tool.

I saw some typos in the README and thought I will quickly fix them and send you a PR.
I wasn't entirely sure about the usage of 'packet lossing', because 'packet loss' is the more common term AND if you want to keep the term as is, you have to omit the second 's' in lossing.

Kind Regards,
Chris 